### PR TITLE
feat: add Close command and extended debug logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.2.0"
-source = "git+https://github.com/pop-os/cosmic-protocols#160b086abe03cd34a8a375d7fbe47b24308d1f38"
+source = "git+https://github.com/pop-os/cosmic-protocols#8a566624225989629171e732a29e643097a6bea2"
 dependencies = [
  "bitflags",
  "wayland-backend",
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "itoa"
@@ -97,15 +97,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nu-ansi-term"
@@ -157,33 +157,33 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -207,9 +207,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "valuable"
@@ -377,9 +377,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.12"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags",
  "rustix",
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.10"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
  "bitflags",
  "wayland-backend",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9597cdf02cf0c34cd5823786dce6b5ae8598f05c2daf5621b6e178d4f7345f3"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
  "bitflags",
  "wayland-backend",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.8"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-server"
-version = "0.31.11"
+version = "0.31.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9297ab90f8d1f597711d36455c5b1b2290eca59b8134485e377a296b80b118c9"
+checksum = "cc1846eb04c49182e04f4a099e2a830a2b745610bbc1d61246e206f29c7000a0"
 dependencies = [
  "bitflags",
  "downcast-rs",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.8"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "pkg-config",
 ]

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -298,6 +298,26 @@ impl Dispatch<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, ()> for App
         _: &QueueHandle<Self>,
     ) {
         tracing::debug!(event = ?event, proxy = ?proxy, "ZcosmicToplevelManagerV1");
+        if let zcosmic_toplevel_manager_v1::Event::Capabilities { capabilities } = event {
+            let caps: Vec<u32> = capabilities
+                .chunks_exact(4)
+                .map(|chunk| u32::from_ne_bytes(chunk.try_into().unwrap()))
+                .collect();
+            let supports_close = caps.contains(&1);
+            let supports_activate = caps.contains(&2);
+            let supports_maximize = caps.contains(&3);
+            let supports_minimize = caps.contains(&4);
+            let supports_fullscreen = caps.contains(&5);
+            tracing::debug!(
+                "Compositor capabilities: close={}, activate={}, maximize={}, minimize={}, fullscreen={} (raw: {:?})",
+                supports_close,
+                supports_activate,
+                supports_maximize,
+                supports_minimize,
+                supports_fullscreen,
+                caps,
+            );
+        }
     }
 }
 
@@ -342,6 +362,17 @@ impl Dispatch<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, ()> for AppSt
         _: &QueueHandle<AppState>,
     ) {
         tracing::debug!(event = ?event, proxy = ?toplevel, "ZcosmicToplevelHandleV1");
+        if let zcosmic_toplevel_handle_v1::Event::Closed = event {
+            let app_id = app_data
+                .apps
+                .iter()
+                .find(|t| &t.handle == toplevel)
+                .and_then(|a| a.app_id.clone())
+                .unwrap_or_default();
+            tracing::debug!("Toplevel closed by compositor: {}", app_id);
+            app_data.apps.retain(|t| &t.handle != toplevel);
+            return;
+        }
         let Some(info) = app_data.apps.iter_mut().find(|t| &t.handle == toplevel) else {
             return;
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ Commands:
   move                          Move an application to a specific workspace
   activate                      Activate an application on a specific seat
   state                         Set state of an application
+  close                         Close an application
 
 Options for 'move':
   -a, --app-id <ID>             The Application ID (partial match, case-insensitive)
@@ -63,6 +64,11 @@ Options for 'state':
   --sticky
   --unsticky
 
+Options for 'close':
+  -a, --app-id <ID>             The Application ID (partial match, case-insensitive)
+  -i, --index <INDEX>           The Application index from 'info' command
+  --wait <SECONDS>              Wait for the app to appear (optional, only for --app-id)
+
 Options for 'info':
   --json                        Output in JSON format
   --discover-wg-output          Try to find info relation about workspace group and output
@@ -80,6 +86,9 @@ Examples:
   cos-cli activate -i 0
   cos-cli state -i 0 --maximize
   cos-cli state --app-id firefox --sticky --fullscreen
+  cos-cli close -i 0
+  cos-cli close --app-id firefox
+  cos-cli close -a terminal --wait 5
 ";
 
 struct CliError(String);
@@ -315,6 +324,13 @@ struct StateArgs {
     unsticky: bool,
 }
 
+#[derive(Debug)]
+struct CloseArgs {
+    app_id: Option<String>,
+    app_index: Option<usize>,
+    wait: Option<u64>,
+}
+
 trait AppFinderArgs {
     fn app_index(&self) -> Option<usize>;
     fn app_id(&self) -> Option<&String>;
@@ -349,6 +365,20 @@ impl AppFinderArgs for StateArgs {
     }
 }
 
+impl AppFinderArgs for CloseArgs {
+    fn app_index(&self) -> Option<usize> {
+        self.app_index
+    }
+
+    fn app_id(&self) -> Option<&String> {
+        self.app_id.as_ref()
+    }
+
+    fn wait(&self) -> Option<u64> {
+        self.wait
+    }
+}
+
 #[derive(Debug)]
 struct InfoArgs {
     json: bool,
@@ -360,6 +390,7 @@ enum Command {
     Move(MoveArgs),
     Activate(ActivateArgs),
     State(StateArgs),
+    Close(CloseArgs),
 }
 
 fn find_apps<T: AppFinderArgs>(
@@ -507,6 +538,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             Command::State(args)
+        }
+        Some("close") => {
+            let app_id: Option<String> = pargs.opt_value_from_str(["-a", "--app-id"])?;
+            let app_index: Option<usize> = pargs.opt_value_from_str(["-i", "--index"])?;
+
+            if app_id.is_none() && app_index.is_none() {
+                return Err(CliError::new(
+                    "Either --app-id or --index must be provided for 'close' command.".into(),
+                ));
+            }
+            if app_id.is_some() && app_index.is_some() {
+                return Err(CliError::new(
+                    "Only one of --app-id or --index can be provided for 'close' command.".into(),
+                ));
+            }
+
+            Command::Close(CloseArgs {
+                app_id,
+                app_index,
+                wait: pargs.opt_value_from_fn("--wait", |v| v.parse())?,
+            })
         }
         Some("help") | None => {
             println!("{HELP}");
@@ -1047,6 +1099,45 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             conn.flush()?;
+        }
+        Command::Close(args) => {
+            let apps_to_close = find_apps(&mut state, &mut event_queue, &args)?;
+
+            let Some(manager) = &state.cosmic_toplevel_manager else {
+                return Err(CliError::new(
+                    "Compositor does not support toplevel management protocol.".into(),
+                ));
+            };
+
+            let app_count = apps_to_close.len();
+            for app in &apps_to_close {
+                tracing::debug!(
+                    "Sending close request for: {}",
+                    app.app_id.as_deref().unwrap_or("unknown")
+                );
+                manager.close(&app.handle);
+            }
+
+            conn.flush()?;
+
+            event_queue.roundtrip(&mut state)?;
+
+            let remaining = state
+                .apps
+                .iter()
+                .filter(|a| apps_to_close.iter().any(|c| c.handle == a.handle))
+                .count();
+            if remaining == 0 && app_count > 0 {
+                tracing::debug!("All {} app(s) closed successfully", app_count);
+            } else if remaining < app_count {
+                tracing::debug!(
+                    "{}/{} app(s) closed",
+                    app_count - remaining,
+                    app_count
+                );
+            } else {
+                tracing::warn!("App(s) still present after close request. The compositor may not support closing or the app may have refused.");
+            }
         }
     };
 


### PR DESCRIPTION
Motivation was a stuck window, but apparently `Close` only performs graceful shutdowns and when the window is already in an unhealthy state the "Toplevel Manager" does not force any close in the sense a SIGKILL would for example.

Also: Updated protocol crate (and others)